### PR TITLE
Code organization improvements

### DIFF
--- a/src/icmp.c
+++ b/src/icmp.c
@@ -159,4 +159,6 @@ void icmp_main(config_t *config) {
         if (destination_reached(responses, config->num_send, num_recv))
             break;
     }
+
+    close(sockfd);
 }

--- a/src/icmp.h
+++ b/src/icmp.h
@@ -1,8 +1,6 @@
 #ifndef ICMP_H
 #define ICMP_H
 
-#include "common.h"
-
-void icmp_main(config_t *config);
+void icmp_main();
 
 #endif /* !ICMP_H */

--- a/src/main.c
+++ b/src/main.c
@@ -13,17 +13,17 @@
 #include "udp.h"
 #include "common.h"
 
+config_t config = {.wait_time = {.tv_sec = 1, .tv_usec = 0},
+                   .first_ttl = 1,
+                   .max_ttl = 30,
+                   .num_send = 3,
+                   .use_dns = 1,
+                   .mode = MODE_ICMP,
+                   .dest_port = 33434};
 
 int main(int argc, char *argv[]) {
     ssize_t ret;
     int opt;
-    config_t config = {.wait_time = {.tv_sec = 1, .tv_usec = 0},
-                       .first_ttl = 1,
-                       .max_ttl = 30,
-                       .num_send = 3,
-                       .use_dns = 1,
-                       .mode = MODE_ICMP,
-                       .dest_port = 33434};
 
     while ((opt = getopt(argc, argv, "IUnf:m:q:w:s:")) != -1) {
         switch (opt) {
@@ -79,9 +79,9 @@ int main(int argc, char *argv[]) {
         eprintf("inet_pton:");
 
     if (config.mode == MODE_ICMP)
-        icmp_main(&config);
+        icmp_main();
     else if (config.mode == MODE_UDP)
-        udp_main(&config);
+        udp_main();
     else {
         fprintf(stderr, "Unknown traceroute mode: %u\n", config.mode);
         exit(EXIT_FAILURE);

--- a/src/report.c
+++ b/src/report.c
@@ -9,6 +9,8 @@
 #include "common.h"
 
 
+extern config_t config;
+
 static char *reverse_dns_lookup(struct in_addr *ip_addr, char hostname[NI_MAXHOST]) {
     struct sockaddr_in address = {.sin_addr = *ip_addr, .sin_family = AF_INET};
 
@@ -18,7 +20,7 @@ static char *reverse_dns_lookup(struct in_addr *ip_addr, char hostname[NI_MAXHOS
     return hostname;
 }
 
-static void print_ip_addrs(receive_t *responses, int num_recv, int use_dns) {
+static void print_ip_addrs(receive_t *responses, int num_recv) {
     int i, j, num_addrs = 0;
     struct in_addr distinct_addrs[num_recv];
     char ip_addr_buf[INET_ADDRSTRLEN];
@@ -36,7 +38,7 @@ static void print_ip_addrs(receive_t *responses, int num_recv, int use_dns) {
         memset(ip_addr_buf, 0, sizeof(ip_addr_buf));
         if (!inet_ntop(AF_INET, &(distinct_addrs[i]), ip_addr_buf, INET_ADDRSTRLEN))
             eprintf("inet_ntop:");
-        if (!use_dns)
+        if (!config.use_dns)
             printf(" %s", ip_addr_buf);
         else if (reverse_dns_lookup(&(distinct_addrs[i]), hostname))
             printf(" %s (%s)", hostname, ip_addr_buf);
@@ -57,7 +59,7 @@ static void print_avg_time(receive_t *responses, int num_recv) {
     printf("%.3fms", (double)elapsed_us / 1000 / num_recv);
 }
 
-void print_report(int ttl, receive_t *responses, int num_send, int num_recv, int use_dns) {
+void print_report(int ttl, receive_t *responses, int num_recv) {
     if (num_recv == 0) {
         printf("%d. *\n", ttl);
         return;
@@ -65,11 +67,11 @@ void print_report(int ttl, receive_t *responses, int num_send, int num_recv, int
 
     printf("%d.", ttl);
 
-    print_ip_addrs(responses, num_recv, use_dns);
+    print_ip_addrs(responses, num_recv);
 
     printf("  ");
 
-    if (num_send < num_recv)
+    if (config.num_send < num_recv)
         printf("???");
     else
         print_avg_time(responses, num_recv);

--- a/src/report.h
+++ b/src/report.h
@@ -2,8 +2,9 @@
 #define REPORT_H
 
 #include "icmp.h"
+#include "common.h"
 
 
-void print_report(int ttl, receive_t *responses, int num_send, int num_recv, int use_dns);
+void print_report(int ttl, receive_t *responses, int num_recv);
 
 #endif /* !REPORT_H */

--- a/src/udp.c
+++ b/src/udp.c
@@ -119,6 +119,9 @@ static unsigned int receive_icmps(int sockfds[], receive_t *responses, config_t 
         }
     } while (num_recv < config->num_send);
 
+    for (int i = 0; i < config->num_send; i++)
+        close(sockfds[i]);
+
     return num_recv;
 }
 

--- a/src/udp.h
+++ b/src/udp.h
@@ -1,8 +1,6 @@
 #ifndef UDP_H
 #define UDP_H
 
-#include "common.h"
-
-void udp_main(config_t *config);
+void udp_main();
 
 #endif /* !UDP_H */


### PR DESCRIPTION
If we have only one socket from which UDP probes are sent, it may happen that while `n+1` probe is being sent, the socket has already received an error (related to `n` probe) to its *errqueue*. In such situation, sending `n+1` packet will fail with `ECONNREFUSED`.

This PR fixes such errors by creating a separate socket for each UDP probe. Also, some minor improvements to code structure organization are introduced.
